### PR TITLE
"connection_string" is provided for AzureExporter

### DIFF
--- a/azure_monitor/flask_sample/config.py
+++ b/azure_monitor/flask_sample/config.py
@@ -9,14 +9,14 @@ class Config(object):
         'sqlite:///' + os.path.join(basedir, 'app.db')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     INSTRUMENTATION_KEY = os.environ.get('APPINSIGHTS_INSTRUMENTATIONKEY') or \
-        '<your-ikey-here>'
+       '<your-ikey-here>'
     CONNECTION_STRING = 'InstrumentationKey=' + INSTRUMENTATION_KEY
     sampler = 'opencensus.trace.samplers.ProbabilitySampler(rate=1.0)'
     OPENCENSUS = {
         'TRACE': {
             'SAMPLER': sampler,
-            'EXPORTER': 'opencensus.ext.azure.trace_exporter.AzureExporter('
-            + CONNECTION_STRING + ')',
+            'EXPORTER': 'opencensus.ext.azure.trace_exporter.AzureExporter(connection_string="'
+            + CONNECTION_STRING + '")',
             'BLACKLIST_PATHS': ['blacklist'],
         }
     }


### PR DESCRIPTION
Once we try to run sample application, it shows a syntax error for `AzureExporter`:
![image](https://user-images.githubusercontent.com/118657/111177551-63857000-85bb-11eb-9f9d-949c2e23a1d1.png)

It seems like `AzureExporter` requires "connection_string" for parameter with new version of OpenCensus package, after small change sample runs successfully.
```python
    OPENCENSUS = {
        'TRACE': {
            'SAMPLER': sampler,
            'EXPORTER': 'opencensus.ext.azure.trace_exporter.AzureExporter(connection_string="'+ CONNECTION_STRING + '")',
            'BLACKLIST_PATHS': ['blacklist'],
        }
    }

```

Package versions on my local machine are like below:
![image](https://user-images.githubusercontent.com/118657/111177804-a34c5780-85bb-11eb-80d7-d9a12c3256d2.png)

