### PR TITLE
Increased export interval to avoid CPU overhead

### DIFF
--- a/azure_monitor/python_logger_opencensus_azure/monitoring/src/logger.py
+++ b/azure_monitor/python_logger_opencensus_azure/monitoring/src/logger.py
@@ -59,7 +59,7 @@ class AppLogger:
         )
         app_insights_cs = "InstrumentationKey=" + self._get_app_insights_key()
         log_handler = AzureLogHandler(
-            connection_string=app_insights_cs, export_interval=0.0
+            connection_string=app_insights_cs, export_interval=5.0
         )
         log_handler.add_telemetry_processor(self._get_callback(component_name))
         log_handler.name = self.HANDLER_NAME


### PR DESCRIPTION
We've experienced overhead in CPU utilization when export_interval was set to 0.0 (in a fastapi application, using uvicorn server).

Changing to 5.0 solved our issues